### PR TITLE
Make GHC 3.2 only and add some cool stuff from 3.2

### DIFF
--- a/githubcards/__init__.py
+++ b/githubcards/__init__.py
@@ -1,7 +1,14 @@
+from redbot import version_info, VersionInfo
+from redbot.core.bot import Red
+from redbot.core.errors import CogLoadError
+
 from .core import GitHubCards
 
+if version_info < VersionInfo.from_str("3.2.0"):
+    raise CogLoadError("This cog requires at least Red 3.2.0 to work.")
 
-async def setup(bot):
+
+async def setup(bot: Red) -> None:
     cog = GitHubCards(bot)
-    await cog._set_token()
+    await cog.initialize()
     bot.add_cog(cog)

--- a/githubcards/core.py
+++ b/githubcards/core.py
@@ -2,6 +2,7 @@ import discord
 import asyncio
 import logging
 import re
+from typing import Mapping, Optional
 
 from redbot import VersionInfo, version_info as red_version
 from redbot.core import checks, commands, Config
@@ -40,7 +41,7 @@ class GitHubCards(commands.Cog):
         self.active_prefix_matchers = {}
         self.splitter = re.compile(r"[!?().,;:+|&/`\s]")
         self._ready = asyncio.Event()
-        self._startup_task = asyncio.create_task(self.get_ready())
+        self.http: GitHubAPI = None  # assigned in initialize()
 
         self.stateColours = {  # Can't be bothered to do this properly ATM
             'OPEN': 0x6cc644,
@@ -48,10 +49,10 @@ class GitHubCards(commands.Cog):
             'MERGED': 0x6e5494
         }
 
-    async def get_ready(self):
+    async def initialize(self):
         """ cache preloading """
         await self.rebuild_cache_for_guild()
-        await self._set_token()
+        await self._create_client()
         self._ready.set()
 
     async def rebuild_cache_for_guild(self, *guild_ids):
@@ -73,23 +74,31 @@ class GitHubCards(commands.Cog):
         await self._ready.wait()
 
     def cog_unload(self):
-        try:
-            self.http.session.detach()
-        except AttributeError:
-            pass
+        self.bot.loop.create_task(self.http.session.close())
 
-    async def _set_token(self) -> bool:
-        """Get the token and prepare the header"""
-        try:  # Legacy edition
-            github_keys = await self.bot.db.api_tokens.get_raw("github", default={"token": None})
-        except AttributeError:
-            github_keys = await self.bot.get_shared_api_tokens("github")
+    async def _get_token(self, api_tokens: Optional[Mapping[str, str]] = None) -> str:
+        """Get GitHub token."""
+        if api_tokens is None:
+            api_tokens = await self.bot.get_shared_api_tokens("github")
 
-        if github_keys.get("token") is None:
+        token = api_tokens.get("token", "")
+        if not token:
             log.error("No valid token found")
-            return False
-        self.http = GitHubAPI(token=github_keys["token"])
-        return True
+        return token
+
+    async def _create_client(self) -> None:
+        """Create GitHub API client."""
+        self.http = GitHubAPI(token=await self._get_token())
+
+    @commands.Cog.listener()
+    async def on_red_api_tokens_update(
+        self, service_name: str, api_tokens: Mapping[str, str]
+    ):
+        """Update GitHub token when `[p]set api` command is used."""
+        if service_name != "github":
+            return
+
+        await self.http.recreate_session(await self._get_token(api_tokens))
 
     @commands.guild_only()
     @commands.command(usage="<prefix> <search_query>")
@@ -215,39 +224,6 @@ Finally reload the cog with ``[p]reload githubcards`` and you're set to add in n
             embed.add_field(name="Milestone", value=issue_data.milestone)
         return embed
 
-    async def version_safe_allowed(self, who: discord.Member):
-        if red_version >= VersionInfo.from_str("3.2.0"):
-            return await self.bot.allowed_by_whitelist_blacklist(who)
-        else:
-
-            guild = who.guild
-
-            if await self.bot.is_owner(who):
-                return True
-
-            global_whitelist = await self.bot.db.whitelist()
-            if global_whitelist:
-                if who.id not in global_whitelist:
-                    return False
-            else:
-                # blacklist is only used when whitelist doesn't exist.
-                global_blacklist = await self.bot.db.blacklist()
-                if who.id in global_blacklist:
-                    return False
-
-            ids = {i for i in (who.id, *(who._roles)) if i != guild.id}
-
-            guild_whitelist = await self.bot.db.guild(guild).whitelist()
-            if guild_whitelist:
-                if ids.isdisjoint(guild_whitelist):
-                    return False
-            else:
-                guild_blacklist = await self.bot.db.guild(guild).blacklist()
-                if not ids.isdisjoint(guild_blacklist):
-                    return False
-
-            return True
-
     @commands.Cog.listener()
     async def on_message_without_command(self, message):
         await self._ready.wait()
@@ -259,9 +235,8 @@ Finally reload the cog with ``[p]reload githubcards`` and you're set to add in n
         guild = message.guild
         if guild is None:
             return  # End the function here if its anything but a guild.
-        #  if not await self.version_safe_allowed(message.author):
-        #       return  # There, version safe allowed func in.
-        # TODO To be fixed at an later date. We can go without blacklisting for now.
+        if not await self.bot.allowed_by_whitelist_blacklist(message.author):
+            return
 
         cache = self.active_prefix_matchers.get(guild.id, None)
         if not cache:

--- a/githubcards/exceptions.py
+++ b/githubcards/exceptions.py
@@ -4,3 +4,7 @@ class RepoNotFound(Exception):
 
 class ApiError(Exception):
     pass
+
+
+class Unauthorized(ApiError):
+    pass

--- a/githubcards/http.py
+++ b/githubcards/http.py
@@ -12,7 +12,15 @@ log = logging.getLogger("red.githubcards.http")
 
 
 class GitHubAPI:
-    def __init__(self, token: str = None):
+    def __init__(self, token: str) -> None:
+        self.session: aiohttp.ClientSession
+        self._create_session(token)
+
+    async def recreate_session(self, token: str) -> None:
+        await self.session.close()
+        self._create_session(token)
+
+    def _create_session(self, token: str) -> None:
         headers = {
             "Authorization": f"bearer {token}",
             "Content-Type": "application/json",

--- a/githubcards/info.json
+++ b/githubcards/info.json
@@ -1,0 +1,22 @@
+{
+    "name": "GitHubCards",
+    "short": "Embed GitHub issues on your discord chat.",
+    "description": "Ever wanted to embed a github issue?! Well **now** you can! With GitHubCards, this sweet cog allows you to embed any issue from any public repo you like by using a unique prefix!\n*Warning: GithubCards will blow your mind!*",
+    "install_msg": "Thanks for installing GithubCards\n\nBefore you'll be able to use this cog, you need to configure a GitHub token, see `[p]ghc instructions` for instructions.\nFor support go to: <https://support.kowlin.xyz>\n\nIf you like my work and want to support me, please consider becoming a Patron over at <https://patreon.com/kowlin>",
+    "author": [
+        "Kowlin (Kowlin#2536)",
+        "jack1142 (Jackenmen#6607)",
+        "mikeshardmind (Sinbad#1871)"
+    ],
+    "required_cogs": {},
+    "requirements": [],
+    "tags": [
+        "api",
+        "github",
+        "utility"
+    ],
+    "min_bot_version": "3.2.0",
+    "hidden": false,
+    "disabled": false,
+    "type": "COG"
+}


### PR DESCRIPTION
- added proper api tokens support
- added error handling for invalid token
- readded whitelist/blacklist support
- added info.json file for the cog
- GHC now requires at least Red 3.2 (I've been waiting for 26 to update first 😄)