### PR TITLE
Raise Unauthorized in send_query when 401 recived

### DIFF
--- a/githubcards/http.py
+++ b/githubcards/http.py
@@ -137,6 +137,8 @@ class GitHubAPI:
             }
         ) as call:
             json = await call.json()
+            if call.status == 401:
+                raise Unauthorized(json["message"])
             self._log_ratelimit(self.send_query, call.headers)
             return json
 


### PR DESCRIPTION
For whatever reason my GH token became invalid, and trying to bring up a card results in a rather unfriendly error in the console:
![image](https://user-images.githubusercontent.com/51716387/235992194-a089985b-76ff-465a-bc4e-2e989684a36d.png)

After some digging, GitHub was responding with this JSON and status code 401:
```
 {'message': 'Bad credentials', 'documentation_url': 'https://docs.github.com/graphql'}
```

This PR makes http.send_query raise Unauthorized when appropriate, for the existing logic in _query_and_post to send a more user-friendly error message explaining the actual reason for the error.