### PR TITLE
Fix missing d.py 2.x migration in freshmeat

### DIFF
--- a/freshmeat/freshmeat.py
+++ b/freshmeat/freshmeat.py
@@ -57,7 +57,7 @@ class Freshmeat(BaseCog):
             embed = discord.Embed(description=page)
             embed.set_author(
                 name=f"{ctx.author.display_name}'s freshmeat of the day.",
-                icon_url=ctx.author.avatar.url
+                icon_url=ctx.author.display_avatar,
             )
             pages.append(embed)
 

--- a/freshmeat/freshmeat.py
+++ b/freshmeat/freshmeat.py
@@ -57,7 +57,7 @@ class Freshmeat(BaseCog):
             embed = discord.Embed(description=page)
             embed.set_author(
                 name=f"{ctx.author.display_name}'s freshmeat of the day.",
-                icon_url=ctx.author.avatar_url_as(format="png")
+                icon_url=ctx.author.avatar.url
             )
             pages.append(embed)
 


### PR DESCRIPTION
This fixes the 'Member' object has no attribute 'avatar_url_as' error