### PR TITLE
SentryIO - logging, satus command

### DIFF
--- a/sentryio/core.py
+++ b/sentryio/core.py
@@ -51,7 +51,7 @@ class SentryIO(commands.Cog):
         sentry_sdk.init(
             dsn,
             traces_sample_rate=1.0,
-            shutdown_timeout=0.1,
+            shutdown_timeout=0,
             integrations=[
                 AioHttpIntegration(),
                 LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
@@ -62,7 +62,7 @@ class SentryIO(commands.Cog):
         client = sentry_sdk.Hub.current.client
         if client is not None:
             log.info("Closing Sentry client")
-            client.close()
+            client.close(timeout=0)
 
     async def startup(self) -> None:
         self.init_sentry(await self._get_dsn())

--- a/sentryio/core.py
+++ b/sentryio/core.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Mapping, Optional
 
@@ -21,7 +22,7 @@ class SentryIO(commands.Cog):
         self.bot = bot
 
     async def cog_load(self) -> None:
-        self.init_sentry(await self._get_dsn())
+        asyncio.create_task(self.startup())
 
     def cog_unload(self) -> None:
         self.close_sentry()
@@ -62,6 +63,9 @@ class SentryIO(commands.Cog):
         if client is not None:
             log.info("Closing Sentry client")
             client.close()
+
+    async def startup(self) -> None:
+        self.init_sentry(await self._get_dsn())
 
     @commands.group(name="sentryio")  # type: ignore
     @checks.is_owner()


### PR DESCRIPTION
Added the following:
- logging for when the sentry client is initialized
- logging for when it is closed
- status command for viewing if the client is initialized
- include currently saved dsn in modal default text for the api view (if exists)

Misc:
- linter formatting for the fstring responses
- type annotation for self.bot
- explicitly check if dsn string is truthy before trying to init sentry
- cog_load now creates a task instead of awaiting within the function